### PR TITLE
Update issue reference in git guidelines

### DIFF
--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -28,10 +28,6 @@ Delete your branch from the upstream repository after it's merged, unless there 
 
 ## Commit message
 
-Subject of a message should end with the reference to the issue. You can find issue number right after its name.
-
-e.g: `#11` refers to *Discuss folder and project structures* issue, so commit message might be *Add git guidelines #11*
-
 Message should correspond to the next rules:
 
 #### The seven rules of a great Git commit message
@@ -44,6 +40,14 @@ Message should correspond to the next rules:
 7. Use the body to explain what and why vs. how
 
 More details with examples: [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/)
+
+## Pull reqest
+
+#### Description
+
+Description of a pull request should contain a reference to the issue. You can find issue number (reference) right after its name.
+
+e.g: `#11` refers to *Discuss folder and project structures* issue, so a pull request description might end with *Should resolve #11*
 
 ## Issues
 


### PR DESCRIPTION
As a pull request contains all related commits there is no need to put a reference at the end of each commit message. The reference can be put only once in a pull request description so it appear in the issue history. To find a certain commit that resolves issue we can use this path: Issue -> Pull request -> Commit.